### PR TITLE
Make ign topics for plugins user definable

### DIFF
--- a/include/gazebo_magnetometer_plugin.h
+++ b/include/gazebo_magnetometer_plugin.h
@@ -63,7 +63,7 @@
 
 namespace magnetometer_plugin {
 
-  static constexpr auto kDefaultMagnetometerTopic = "mag";
+  static constexpr auto kDefaultMagnetometerTopic = "/mag";
   static constexpr auto kDefaultPubRate = 100.0; // [Hz]. Note: corresponds to most of the mag devices supported in PX4
 
   // Default values for use with ADIS16448 IMU
@@ -99,7 +99,7 @@ namespace magnetometer_plugin {
       ignition::gazebo::Model model_{ignition::gazebo::kNullEntity};
       ignition::gazebo::Entity model_link_{ignition::gazebo::kNullEntity};
 
-      std::string mag_topic_;
+      std::string mag_pub_topic_;
       ignition::transport::Node node;
       ignition::transport::Node::Publisher pub_mag_;
       std::string gt_sub_topic_;

--- a/include/gazebo_mavlink_interface.h
+++ b/include/gazebo_mavlink_interface.h
@@ -173,6 +173,7 @@ namespace mavlink_interface
       std::string vision_sub_topic_{kDefaultVisionTopic};
       std::string mag_sub_topic_{kDefaultMagTopic};
       std::string baro_sub_topic_{kDefaultBarometerTopic};
+      std::string imu_sub_topic_{kDefaultImuTopic};
 
       std::mutex last_imu_message_mutex_ {};
 

--- a/models/x3/model.sdf
+++ b/models/x3/model.sdf
@@ -36,7 +36,7 @@
           <always_on>1</always_on>
           <update_rate>250</update_rate>
           <visualize>true</visualize>
-          <topic>imu</topic>
+          <topic>px4_demo/imu</topic>
       </sensor>
     </link>
     <link name='X3/rotor_0'>
@@ -303,16 +303,19 @@
       filename="libgazebo_barometer_plugin.so"
       name="barometer_plugin::BarometerPlugin">
       <link_name>X3/base_link</link_name>
+      <baroPubTopic>px4_demo/baro</baroPubTopic>
     </plugin>
     <plugin
       filename="libgazebo_magnetometer_plugin.so"
       name="magnetometer_plugin::MagnetometerPlugin">
       <link_name>X3/base_link</link_name>
+      <magPubTopic>px4_demo/mag</magPubTopic>
     </plugin>
     <plugin
       filename="libgazebo_gps_plugin.so"
       name="gps_plugin::GpsPlugin">
       <link_name>X3/base_link</link_name>
+      <gpsPubTopic>px4_demo/gps</gpsPubTopic>
     </plugin>
   </model>
 </sdf>

--- a/src/gazebo_barometer_plugin.cpp
+++ b/src/gazebo_barometer_plugin.cpp
@@ -57,7 +57,6 @@ using namespace barometer_plugin;
 
 BarometerPlugin::BarometerPlugin()
 {
-  pub_baro_ = this->node.Advertise<sensor_msgs::msgs::Pressure>("/world/quadcopter/model/X3/link/base_link/sensor/barometer");
 }
 
 BarometerPlugin::~BarometerPlugin() {
@@ -71,6 +70,13 @@ void BarometerPlugin::Configure(const ignition::gazebo::Entity &_entity,
     model_ = ignition::gazebo::Model(_entity);
     // Get link entity
     model_link_ = model_.LinkByName(_ecm, linkName);
+
+    std::string baro_pub_topic{"/baro"};
+    if(_sdf->HasElement("baroPubTopic")){
+      baro_pub_topic = _sdf->Get<std::string>("baroPubTopic");
+    }
+
+    pub_baro_ = this->node.Advertise<sensor_msgs::msgs::Pressure>(baro_pub_topic);
 
   if(!_ecm.EntityHasComponentType(model_link_, ignition::gazebo::components::WorldPose::typeId))
   {

--- a/src/gazebo_gps_plugin.cpp
+++ b/src/gazebo_gps_plugin.cpp
@@ -40,7 +40,6 @@ using namespace gps_plugin;
 
 GpsPlugin::GpsPlugin()
 {
-  pub_gps_ = this->node.Advertise<sensor_msgs::msgs::SITLGps>("/world/quadcopter/model/X3/link/base_link/sensor/gps");
 }
 
 GpsPlugin::~GpsPlugin() {
@@ -54,6 +53,12 @@ void GpsPlugin::Configure(const ignition::gazebo::Entity &_entity,
   const char *env_lat = std::getenv("PX4_HOME_LAT");
   const char *env_lon = std::getenv("PX4_HOME_LON");
   const char *env_alt = std::getenv("PX4_HOME_ALT");
+
+  std::string gps_pub_topic{"/gps"};
+  if(_sdf->HasElement("gpsPubTopic")){
+    gps_pub_topic = _sdf->Get<std::string>("gpsPubTopic");
+  }
+  pub_gps_ = this->node.Advertise<sensor_msgs::msgs::SITLGps>(gps_pub_topic);
 
   if (env_lat) {
     lat_home_ = std::stod(env_lat) * M_PI / 180.0;

--- a/src/gazebo_magnetometer_plugin.cpp
+++ b/src/gazebo_magnetometer_plugin.cpp
@@ -91,11 +91,11 @@ void MagnetometerPlugin::getSdfParams(const std::shared_ptr<const sdf::Element> 
     ignwarn << "[gazebo_magnetometer_plugin] Using default bias correlation time of " << random_walk_ << " s\n";
   }
 
-  if(sdf->HasElement("magTopic")) {
-    mag_topic_ = sdf->Get<std::string>("magTopic");
+  if(sdf->HasElement("magPubTopic")) {
+    mag_pub_topic_ = sdf->Get<std::string>("magPubTopic");
   } else {
-    mag_topic_ = kDefaultMagnetometerTopic;
-    ignwarn << "[gazebo_magnetometer_plugin] Using default magnetometer topic " << mag_topic_ << "\n";
+    mag_pub_topic_ = kDefaultMagnetometerTopic;
+    ignwarn << "[gazebo_magnetometer_plugin] Using default magnetometer topic " << mag_pub_topic_ << "\n";
   }
 
   gt_sub_topic_ = "/groundtruth";
@@ -109,7 +109,7 @@ void MagnetometerPlugin::Configure(const ignition::gazebo::Entity &_entity,
 {
   getSdfParams(_sdf);
 
-  pub_mag_ = this->node.Advertise<sensor_msgs::msgs::MagneticField>("/world/quadcopter/model/X3/link/base_link/sensor/magnetometer");
+  pub_mag_ = this->node.Advertise<sensor_msgs::msgs::MagneticField>(mag_pub_topic_);
   node.Subscribe(gt_sub_topic_, &MagnetometerPlugin::GroundtruthCallback, this);
 
   standard_normal_distribution_ = std::normal_distribution<double>(0.0, 1.0);

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -70,6 +70,7 @@ void GazeboMavlinkInterface::Configure(const ignition::gazebo::Entity &_entity,
   gazebo::getSdfParam<std::string>(_sdf, "irlockSubTopic", irlock_sub_topic_, irlock_sub_topic_);
   gazebo::getSdfParam<std::string>(_sdf, "magSubTopic", mag_sub_topic_, mag_sub_topic_);
   gazebo::getSdfParam<std::string>(_sdf, "baroSubTopic", baro_sub_topic_, baro_sub_topic_);
+  gazebo::getSdfParam<std::string>(_sdf, "imuSubTopic", imu_sub_topic_, imu_sub_topic_);
   groundtruth_sub_topic_ = "/groundtruth";
 
   // set input_reference_ from inputs.control
@@ -139,10 +140,10 @@ void GazeboMavlinkInterface::Configure(const ignition::gazebo::Entity &_entity,
   sigIntConnection_ = _em.Connect<ignition::gazebo::events::Stop>(std::bind(&GazeboMavlinkInterface::onSigInt, this));
 
   // Subscribe to messages of other plugins.
-  node.Subscribe("/imu", &GazeboMavlinkInterface::ImuCallback, this);
-  node.Subscribe("/world/quadcopter/model/X3/link/base_link/sensor/barometer", &GazeboMavlinkInterface::BarometerCallback, this);
-  node.Subscribe("/world/quadcopter/model/X3/link/base_link/sensor/magnetometer", &GazeboMavlinkInterface::MagnetometerCallback, this);
-  node.Subscribe("/world/quadcopter/model/X3/link/base_link/sensor/gps", &GazeboMavlinkInterface::GpsCallback, this);
+  node.Subscribe(imu_sub_topic_, &GazeboMavlinkInterface::ImuCallback, this);
+  node.Subscribe(baro_sub_topic_, &GazeboMavlinkInterface::BarometerCallback, this);
+  node.Subscribe(mag_sub_topic_, &GazeboMavlinkInterface::MagnetometerCallback, this);
+  node.Subscribe(gps_sub_topic_, &GazeboMavlinkInterface::GpsCallback, this);
 
   // This doesn't seem to be used anywhere but we leave it here
   // for potential compatibility

--- a/worlds/iris.world
+++ b/worlds/iris.world
@@ -218,9 +218,10 @@
           filename="libmavlink_sitl_ign_gazebo.so"
           name="mavlink_interface::GazeboMavlinkInterface">
                 <robotNamespace/>
-        <imuSubTopic>/imu</imuSubTopic>
-        <magSubTopic>/mag</magSubTopic>
-        <baroSubTopic>/baro</baroSubTopic>
+        <imuSubTopic>px4_demo/imu</imuSubTopic>
+        <magSubTopic>px4_demo/mag</magSubTopic>
+        <baroSubTopic>px4_demo/baro</baroSubTopic>
+        <gpsSubTopic>px4_demo/gps</gpsSubTopic>
         <mavlink_addr>INADDR_ANY</mavlink_addr>
         <mavlink_udp_port>14560</mavlink_udp_port>
         <mavlink_tcp_port>4560</mavlink_tcp_port>


### PR DESCRIPTION
Fixes issue [#19981](https://github.com/PX4/PX4-Autopilot/issues/19981) from PX4-Autopilot.

Checks applied: Built PX4-Autopilot with this implemented in px4-simulation-ignition and everything worked: QGroundControl connected successfully with the UAV, and arming worked as it did before applying this update.

EDIT: Importantly, the ign-topics now correspond exactly to the topics given to the plugins.